### PR TITLE
Adding friends functionality

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,28 @@
+# Development Guidelines
+
+## Build Commands
+- `pnpm dev` - Start development server with Turbo
+- `pnpm build` - Build for production
+- `pnpm lint` - Run ESLint
+- `pnpm lint:fix` - Fix linting errors
+- `pnpm check` - Run lint + type checking
+- `pnpm typecheck` - Run TypeScript type checking
+- `pnpm format:write` - Format code with Prettier
+- `pnpm format:check` - Check formatting
+
+## Database
+- `pnpm db:generate` - Generate Drizzle migrations
+- `pnpm db:studio` - Open Drizzle Studio
+
+## Code Style
+- TypeScript with strict type checking
+- 4-space indentation
+- Trailing commas in multi-line lists
+- Path aliasing: import from `@/` for src directory
+- Component-based architecture
+- React server components by default
+- Use Tailwind for styling
+- Prefix unused variables with underscore
+- Use Zod for validation
+- Use React Query for data fetching
+- Follow Next.js App Router conventions

--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
         "@radix-ui/react-progress": "^1.1.1",
         "@radix-ui/react-select": "^2.1.5",
         "@radix-ui/react-slot": "^1.1.1",
+        "@radix-ui/react-tabs": "^1.1.3",
         "@react-aria/datepicker": "^3.13.0",
         "@react-stately/datepicker": "^3.12.0",
         "@remixicon/react": "^4.6.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -44,6 +44,9 @@ importers:
       '@radix-ui/react-slot':
         specifier: ^1.1.1
         version: 1.1.1(@types/react@19.0.8)(react@19.0.0)
+      '@radix-ui/react-tabs':
+        specifier: ^1.1.3
+        version: 1.1.3(@types/react-dom@19.0.3(@types/react@19.0.8))(@types/react@19.0.8)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
       '@react-aria/datepicker':
         specifier: ^3.13.0
         version: 3.13.0(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
@@ -864,6 +867,19 @@ packages:
       '@types/react-dom':
         optional: true
 
+  '@radix-ui/react-collection@1.1.2':
+    resolution: {integrity: sha512-9z54IEKRxIa9VityapoEYMuByaG42iSy1ZXlY2KcuLSEtq8x4987/N6m15ppoMffgZX72gER2uHe1D9Y6Unlcw==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
   '@radix-ui/react-compose-refs@1.1.1':
     resolution: {integrity: sha512-Y9VzoRDSJtgFMUCoiZBDVo084VQ5hfpXxVE+NgkdNsjiDBByiImMZKKhxMwCbdHvhlENG6a833CbFkOQvTricw==}
     peerDependencies:
@@ -1052,6 +1068,19 @@ packages:
       '@types/react-dom':
         optional: true
 
+  '@radix-ui/react-primitive@2.0.2':
+    resolution: {integrity: sha512-Ec/0d38EIuvDF+GZjcMU/Ze6MxntVJYO/fRlCPhCaVUyPY9WTalHJw54tp9sXeJo3tlShWpy41vQRgLRGOuz+w==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
   '@radix-ui/react-progress@1.1.1':
     resolution: {integrity: sha512-6diOawA84f/eMxFHcWut0aE1C2kyE9dOyCTQOMRR2C/qPiXz/X0SaiA/RLbapQaXUCmy0/hLMf9meSccD1N0pA==}
     peerDependencies:
@@ -1067,6 +1096,19 @@ packages:
 
   '@radix-ui/react-roving-focus@1.1.1':
     resolution: {integrity: sha512-QE1RoxPGJ/Nm8Qmk0PxP8ojmoaS67i0s7hVssS7KuI2FQoc/uzVlZsqKfQvxPE6D8hICCPHJ4D88zNhT3OOmkw==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
+  '@radix-ui/react-roving-focus@1.1.2':
+    resolution: {integrity: sha512-zgMQWkNO169GtGqRvYrzb0Zf8NhMHS2DuEB/TiEmVnpr5OqPU3i8lfbxaAmC2J/KYuIQxyoQQ6DxepyXp61/xw==}
     peerDependencies:
       '@types/react': '*'
       '@types/react-dom': '*'
@@ -1098,6 +1140,28 @@ packages:
       react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
     peerDependenciesMeta:
       '@types/react':
+        optional: true
+
+  '@radix-ui/react-slot@1.1.2':
+    resolution: {integrity: sha512-YAKxaiGsSQJ38VzKH86/BPRC4rh+b1Jpa+JneA5LRE7skmLPNAyeG8kPJj/oo4STLvlrs8vkf/iYyc3A5stYCQ==}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
+  '@radix-ui/react-tabs@1.1.3':
+    resolution: {integrity: sha512-9mFyI30cuRDImbmFF6O2KUJdgEOsGh9Vmx9x/Dh9tOhL7BngmQPQfwW4aejKm5OHpfWIdmeV6ySyuxoOGjtNng==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
         optional: true
 
   '@radix-ui/react-use-callback-ref@1.1.0':
@@ -3862,6 +3926,18 @@ snapshots:
       '@types/react': 19.0.8
       '@types/react-dom': 19.0.3(@types/react@19.0.8)
 
+  '@radix-ui/react-collection@1.1.2(@types/react-dom@19.0.3(@types/react@19.0.8))(@types/react@19.0.8)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)':
+    dependencies:
+      '@radix-ui/react-compose-refs': 1.1.1(@types/react@19.0.8)(react@19.0.0)
+      '@radix-ui/react-context': 1.1.1(@types/react@19.0.8)(react@19.0.0)
+      '@radix-ui/react-primitive': 2.0.2(@types/react-dom@19.0.3(@types/react@19.0.8))(@types/react@19.0.8)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
+      '@radix-ui/react-slot': 1.1.2(@types/react@19.0.8)(react@19.0.0)
+      react: 19.0.0
+      react-dom: 19.0.0(react@19.0.0)
+    optionalDependencies:
+      '@types/react': 19.0.8
+      '@types/react-dom': 19.0.3(@types/react@19.0.8)
+
   '@radix-ui/react-compose-refs@1.1.1(@types/react@19.0.8)(react@19.0.0)':
     dependencies:
       react: 19.0.0
@@ -4059,6 +4135,15 @@ snapshots:
       '@types/react': 19.0.8
       '@types/react-dom': 19.0.3(@types/react@19.0.8)
 
+  '@radix-ui/react-primitive@2.0.2(@types/react-dom@19.0.3(@types/react@19.0.8))(@types/react@19.0.8)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)':
+    dependencies:
+      '@radix-ui/react-slot': 1.1.2(@types/react@19.0.8)(react@19.0.0)
+      react: 19.0.0
+      react-dom: 19.0.0(react@19.0.0)
+    optionalDependencies:
+      '@types/react': 19.0.8
+      '@types/react-dom': 19.0.3(@types/react@19.0.8)
+
   '@radix-ui/react-progress@1.1.1(@types/react-dom@19.0.3(@types/react@19.0.8))(@types/react@19.0.8)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)':
     dependencies:
       '@radix-ui/react-context': 1.1.1(@types/react@19.0.8)(react@19.0.0)
@@ -4078,6 +4163,23 @@ snapshots:
       '@radix-ui/react-direction': 1.1.0(@types/react@19.0.8)(react@19.0.0)
       '@radix-ui/react-id': 1.1.0(@types/react@19.0.8)(react@19.0.0)
       '@radix-ui/react-primitive': 2.0.1(@types/react-dom@19.0.3(@types/react@19.0.8))(@types/react@19.0.8)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
+      '@radix-ui/react-use-callback-ref': 1.1.0(@types/react@19.0.8)(react@19.0.0)
+      '@radix-ui/react-use-controllable-state': 1.1.0(@types/react@19.0.8)(react@19.0.0)
+      react: 19.0.0
+      react-dom: 19.0.0(react@19.0.0)
+    optionalDependencies:
+      '@types/react': 19.0.8
+      '@types/react-dom': 19.0.3(@types/react@19.0.8)
+
+  '@radix-ui/react-roving-focus@1.1.2(@types/react-dom@19.0.3(@types/react@19.0.8))(@types/react@19.0.8)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)':
+    dependencies:
+      '@radix-ui/primitive': 1.1.1
+      '@radix-ui/react-collection': 1.1.2(@types/react-dom@19.0.3(@types/react@19.0.8))(@types/react@19.0.8)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
+      '@radix-ui/react-compose-refs': 1.1.1(@types/react@19.0.8)(react@19.0.0)
+      '@radix-ui/react-context': 1.1.1(@types/react@19.0.8)(react@19.0.0)
+      '@radix-ui/react-direction': 1.1.0(@types/react@19.0.8)(react@19.0.0)
+      '@radix-ui/react-id': 1.1.0(@types/react@19.0.8)(react@19.0.0)
+      '@radix-ui/react-primitive': 2.0.2(@types/react-dom@19.0.3(@types/react@19.0.8))(@types/react@19.0.8)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
       '@radix-ui/react-use-callback-ref': 1.1.0(@types/react@19.0.8)(react@19.0.0)
       '@radix-ui/react-use-controllable-state': 1.1.0(@types/react@19.0.8)(react@19.0.0)
       react: 19.0.0
@@ -4121,6 +4223,29 @@ snapshots:
       react: 19.0.0
     optionalDependencies:
       '@types/react': 19.0.8
+
+  '@radix-ui/react-slot@1.1.2(@types/react@19.0.8)(react@19.0.0)':
+    dependencies:
+      '@radix-ui/react-compose-refs': 1.1.1(@types/react@19.0.8)(react@19.0.0)
+      react: 19.0.0
+    optionalDependencies:
+      '@types/react': 19.0.8
+
+  '@radix-ui/react-tabs@1.1.3(@types/react-dom@19.0.3(@types/react@19.0.8))(@types/react@19.0.8)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)':
+    dependencies:
+      '@radix-ui/primitive': 1.1.1
+      '@radix-ui/react-context': 1.1.1(@types/react@19.0.8)(react@19.0.0)
+      '@radix-ui/react-direction': 1.1.0(@types/react@19.0.8)(react@19.0.0)
+      '@radix-ui/react-id': 1.1.0(@types/react@19.0.8)(react@19.0.0)
+      '@radix-ui/react-presence': 1.1.2(@types/react-dom@19.0.3(@types/react@19.0.8))(@types/react@19.0.8)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
+      '@radix-ui/react-primitive': 2.0.2(@types/react-dom@19.0.3(@types/react@19.0.8))(@types/react@19.0.8)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
+      '@radix-ui/react-roving-focus': 1.1.2(@types/react-dom@19.0.3(@types/react@19.0.8))(@types/react@19.0.8)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
+      '@radix-ui/react-use-controllable-state': 1.1.0(@types/react@19.0.8)(react@19.0.0)
+      react: 19.0.0
+      react-dom: 19.0.0(react@19.0.0)
+    optionalDependencies:
+      '@types/react': 19.0.8
+      '@types/react-dom': 19.0.3(@types/react@19.0.8)
 
   '@radix-ui/react-use-callback-ref@1.1.0(@types/react@19.0.8)(react@19.0.0)':
     dependencies:

--- a/src/app/api/dev/make-all-users-friends/route.ts
+++ b/src/app/api/dev/make-all-users-friends/route.ts
@@ -1,0 +1,125 @@
+import { db } from "@/server/db";
+import { friends } from "@/server/db/schema";
+import { clerkClient } from "@clerk/nextjs/server";
+import { and, eq, or } from "drizzle-orm";
+import { NextResponse } from "next/server";
+
+export const GET = POST;
+
+/**
+ * API endpoint to make all users friends with each other
+ * This is for development purposes only and should be disabled in production
+ */
+export async function POST() {
+    // Security check - only allow in development
+    if (process.env.NODE_ENV === "production") {
+        return NextResponse.json(
+            { error: "This endpoint is only available in development mode" },
+            { status: 403 },
+        );
+    }
+
+    try {
+        // Fetch all users from Clerk
+        const clerkUsers = await (
+            await clerkClient()
+        ).users.getUserList({
+            limit: 100, // Adjust as needed
+        });
+
+        if (!clerkUsers.data || clerkUsers.data.length === 0) {
+            return NextResponse.json(
+                { message: "No users found" },
+                { status: 200 },
+            );
+        }
+
+        const userIds = clerkUsers.data.map((user) => user.id);
+        let friendshipsCreated = 0;
+        const errors: string[] = [];
+
+        // For each user, create a friendship with all other users
+        for (let i = 0; i < userIds.length; i++) {
+            const currentUserId = userIds[i];
+
+            for (let j = i + 1; j < userIds.length; j++) {
+                const friendId = userIds[j];
+
+                // Skip self-friendships
+                if (currentUserId === friendId) continue;
+
+                // If either currentUserId or friendId is undefined, skip the friendship
+                if (!currentUserId || !friendId) continue;
+
+                try {
+                    // Check if a relationship already exists
+                    const existingRelation = await db
+                        .select()
+                        .from(friends)
+                        .where(
+                            or(
+                                and(
+                                    eq(friends.userId, currentUserId),
+                                    eq(friends.friendId, friendId),
+                                ),
+                                and(
+                                    eq(friends.userId, friendId),
+                                    eq(friends.friendId, currentUserId),
+                                ),
+                            ),
+                        );
+
+                    // If relationship exists, update it to accepted if needed
+                    if (existingRelation.length > 0) {
+                        for (const relation of existingRelation) {
+                            if (relation.status !== "accepted") {
+                                await db
+                                    .update(friends)
+                                    .set({ status: "accepted" })
+                                    .where(eq(friends.id, relation.id));
+                                friendshipsCreated++;
+                            }
+                        }
+                    } else {
+                        // Create bidirectional friendship (A -> B and B -> A)
+                        // First direction
+                        await db.insert(friends).values({
+                            userId: currentUserId,
+                            friendId: friendId,
+                            status: "accepted",
+                        });
+
+                        // Second direction
+                        await db.insert(friends).values({
+                            userId: friendId,
+                            friendId: currentUserId,
+                            status: "accepted",
+                        });
+
+                        friendshipsCreated += 2;
+                    }
+                } catch (error) {
+                    console.error(
+                        `Error creating friendship between ${currentUserId} and ${friendId}:`,
+                        error,
+                    );
+                    errors.push(
+                        `Failed to create friendship between ${currentUserId} and ${friendId}`,
+                    );
+                }
+            }
+        }
+
+        return NextResponse.json({
+            success: true,
+            message: `Created ${friendshipsCreated} friendships`,
+            errors: errors.length > 0 ? errors : undefined,
+        });
+    } catch (error) {
+        console.error("Error making users friends:", error);
+        return NextResponse.json(
+            { error: "Failed to make users friends" },
+            { status: 500 },
+        );
+    }
+}

--- a/src/app/friends/_components/friend-list.tsx
+++ b/src/app/friends/_components/friend-list.tsx
@@ -1,0 +1,326 @@
+"use client";
+
+import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
+import { Button } from "@/components/ui/button";
+import { Card, CardContent } from "@/components/ui/card";
+import { format } from "date-fns";
+import { useState } from "react";
+import {
+    acceptFriendRequest,
+    rejectFriendRequest,
+    removeFriend,
+} from "../actions";
+
+type FriendInfo = {
+    relationshipId: bigint;
+    userId: string;
+    name: string;
+    imageUrl?: string;
+    initiatedByMe: boolean;
+    createdAt: Date;
+};
+
+export function FriendCard({
+    friend,
+    onAction,
+}: {
+    friend: FriendInfo;
+    onAction?: () => void;
+}) {
+    const [isLoading, setIsLoading] = useState(false);
+
+    const handleRemove = async () => {
+        if (
+            window.confirm(
+                `Are you sure you want to remove ${friend.name} from your friends?`,
+            )
+        ) {
+            setIsLoading(true);
+            await removeFriend(friend.relationshipId);
+            setIsLoading(false);
+            if (onAction) onAction();
+        }
+    };
+
+    return (
+        <Card className="mb-4">
+            <CardContent className="p-6">
+                <div className="flex items-center justify-between">
+                    <div className="flex items-center space-x-4">
+                        <Avatar className="h-12 w-12">
+                            <AvatarImage
+                                src={friend.imageUrl}
+                                alt={friend.name}
+                            />
+                            <AvatarFallback>
+                                {friend.name.substring(0, 2).toUpperCase()}
+                            </AvatarFallback>
+                        </Avatar>
+                        <div>
+                            <h3 className="font-medium">{friend.name}</h3>
+                            <p className="text-sm text-muted-foreground">
+                                Friends since{" "}
+                                {format(
+                                    new Date(friend.createdAt),
+                                    "MMM d, yyyy",
+                                )}
+                            </p>
+                        </div>
+                    </div>
+                    <Button
+                        variant="outline"
+                        size="sm"
+                        onClick={handleRemove}
+                        disabled={isLoading}
+                    >
+                        {isLoading ? "Removing..." : "Remove Friend"}
+                    </Button>
+                </div>
+            </CardContent>
+        </Card>
+    );
+}
+
+export function FriendRequestCard({
+    request,
+    onAction,
+}: {
+    request: FriendInfo;
+    onAction?: () => void;
+}) {
+    const [isLoading, setIsLoading] = useState(false);
+
+    const handleAccept = async () => {
+        setIsLoading(true);
+        await acceptFriendRequest(request.relationshipId);
+        setIsLoading(false);
+        if (onAction) onAction();
+    };
+
+    const handleReject = async () => {
+        setIsLoading(true);
+        await rejectFriendRequest(request.relationshipId);
+        setIsLoading(false);
+        if (onAction) onAction();
+    };
+
+    return (
+        <Card className="mb-4">
+            <CardContent className="p-6">
+                <div className="flex items-center justify-between">
+                    <div className="flex items-center space-x-4">
+                        <Avatar className="h-12 w-12">
+                            <AvatarImage
+                                src={request.imageUrl}
+                                alt={request.name}
+                            />
+                            <AvatarFallback>
+                                {request.name.substring(0, 2).toUpperCase()}
+                            </AvatarFallback>
+                        </Avatar>
+                        <div>
+                            <h3 className="font-medium">{request.name}</h3>
+                            <p className="text-sm text-muted-foreground">
+                                Sent you a request on{" "}
+                                {format(
+                                    new Date(request.createdAt),
+                                    "MMM d, yyyy",
+                                )}
+                            </p>
+                        </div>
+                    </div>
+                    <div className="flex space-x-2">
+                        <Button
+                            variant="default"
+                            size="sm"
+                            onClick={handleAccept}
+                            disabled={isLoading}
+                        >
+                            Accept
+                        </Button>
+                        <Button
+                            variant="outline"
+                            size="sm"
+                            onClick={handleReject}
+                            disabled={isLoading}
+                        >
+                            Decline
+                        </Button>
+                    </div>
+                </div>
+            </CardContent>
+        </Card>
+    );
+}
+
+export function PendingRequestCard({
+    request,
+    onAction,
+}: {
+    request: FriendInfo;
+    onAction?: () => void;
+}) {
+    const [isLoading, setIsLoading] = useState(false);
+
+    const handleCancel = async () => {
+        setIsLoading(true);
+        await rejectFriendRequest(request.relationshipId);
+        setIsLoading(false);
+        if (onAction) onAction();
+    };
+
+    return (
+        <Card className="mb-4">
+            <CardContent className="p-6">
+                <div className="flex items-center justify-between">
+                    <div className="flex items-center space-x-4">
+                        <Avatar className="h-12 w-12">
+                            <AvatarImage
+                                src={request.imageUrl}
+                                alt={request.name}
+                            />
+                            <AvatarFallback>
+                                {request.name.substring(0, 2).toUpperCase()}
+                            </AvatarFallback>
+                        </Avatar>
+                        <div>
+                            <h3 className="font-medium">{request.name}</h3>
+                            <p className="text-sm text-muted-foreground">
+                                Request sent on{" "}
+                                {format(
+                                    new Date(request.createdAt),
+                                    "MMM d, yyyy",
+                                )}
+                            </p>
+                        </div>
+                    </div>
+                    <Button
+                        variant="outline"
+                        size="sm"
+                        onClick={handleCancel}
+                        disabled={isLoading}
+                    >
+                        Cancel Request
+                    </Button>
+                </div>
+            </CardContent>
+        </Card>
+    );
+}
+
+export function FriendsList({
+    friends,
+    title,
+    emptyMessage,
+}: {
+    friends: FriendInfo[];
+    title: string;
+    emptyMessage: string;
+}) {
+    const [refreshKey, setRefreshKey] = useState(0);
+
+    const handleAction = () => {
+        setRefreshKey((prev) => prev + 1);
+    };
+
+    return (
+        <div className="mb-8" key={refreshKey}>
+            <h2 className="mb-4 text-2xl font-bold">{title}</h2>
+            {friends.length === 0 ? (
+                <Card>
+                    <CardContent className="p-6">
+                        <p className="text-center text-muted-foreground">
+                            {emptyMessage}
+                        </p>
+                    </CardContent>
+                </Card>
+            ) : (
+                friends.map((friend) => (
+                    <FriendCard
+                        key={friend.relationshipId}
+                        friend={friend}
+                        onAction={handleAction}
+                    />
+                ))
+            )}
+        </div>
+    );
+}
+
+export function FriendRequestsList({
+    requests,
+    title,
+    emptyMessage,
+}: {
+    requests: FriendInfo[];
+    title: string;
+    emptyMessage: string;
+}) {
+    const [refreshKey, setRefreshKey] = useState(0);
+
+    const handleAction = () => {
+        setRefreshKey((prev) => prev + 1);
+    };
+
+    return (
+        <div className="mb-8" key={refreshKey}>
+            <h2 className="mb-4 text-2xl font-bold">{title}</h2>
+            {requests.length === 0 ? (
+                <Card>
+                    <CardContent className="p-6">
+                        <p className="text-center text-muted-foreground">
+                            {emptyMessage}
+                        </p>
+                    </CardContent>
+                </Card>
+            ) : (
+                requests.map((request) => (
+                    <FriendRequestCard
+                        key={request.relationshipId}
+                        request={request}
+                        onAction={handleAction}
+                    />
+                ))
+            )}
+        </div>
+    );
+}
+
+export function PendingRequestsList({
+    requests,
+    title,
+    emptyMessage,
+}: {
+    requests: FriendInfo[];
+    title: string;
+    emptyMessage: string;
+}) {
+    const [refreshKey, setRefreshKey] = useState(0);
+
+    const handleAction = () => {
+        setRefreshKey((prev) => prev + 1);
+    };
+
+    return (
+        <div className="mb-8" key={refreshKey}>
+            <h2 className="mb-4 text-2xl font-bold">{title}</h2>
+            {requests.length === 0 ? (
+                <Card>
+                    <CardContent className="p-6">
+                        <p className="text-center text-muted-foreground">
+                            {emptyMessage}
+                        </p>
+                    </CardContent>
+                </Card>
+            ) : (
+                requests.map((request) => (
+                    <PendingRequestCard
+                        key={request.relationshipId}
+                        request={request}
+                        onAction={handleAction}
+                    />
+                ))
+            )}
+        </div>
+    );
+}

--- a/src/app/friends/_components/user-search.tsx
+++ b/src/app/friends/_components/user-search.tsx
@@ -1,0 +1,147 @@
+"use client";
+
+import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
+import { Button } from "@/components/ui/button";
+import { Card, CardContent } from "@/components/ui/card";
+import { Input } from "@/components/ui/input";
+import { useEffect, useState } from "react";
+import { searchUsers, sendFriendRequest } from "../actions";
+
+type UserInfo = {
+    id: string;
+    name: string;
+    imageUrl?: string;
+};
+
+export function UserSearch() {
+    const [query, setQuery] = useState("");
+    const [users, setUsers] = useState<UserInfo[]>([]);
+    const [isSearching, setIsSearching] = useState(false);
+    const [actionLoading, setActionLoading] = useState<Record<string, boolean>>(
+        {},
+    );
+    const [searchMessageVisible, setSearchMessageVisible] = useState(false);
+
+    useEffect(() => {
+        let timeoutId: NodeJS.Timeout;
+
+        if (query.length >= 2) {
+            setIsSearching(true);
+            setSearchMessageVisible(false);
+
+            // Debounce search to avoid too many requests
+            timeoutId = setTimeout(() => {
+                void (async () => {
+                    const result = await searchUsers(query);
+                    const usersList = result.users ?? [];
+                    setUsers(usersList);
+                    setIsSearching(false);
+
+                    if (usersList.length === 0) {
+                        setSearchMessageVisible(true);
+                    }
+                })();
+            }, 500);
+        } else {
+            setUsers([]);
+            setIsSearching(false);
+            setSearchMessageVisible(false);
+        }
+
+        return () => {
+            if (timeoutId) clearTimeout(timeoutId);
+        };
+    }, [query]);
+
+    const handleSendRequest = async (userId: string) => {
+        setActionLoading((prev) => ({ ...prev, [userId]: true }));
+
+        try {
+            await sendFriendRequest(userId);
+            // Remove user from search results after sending request
+            setUsers((prev) => prev.filter((user) => user.id !== userId));
+        } catch (error) {
+            console.error("Error sending friend request:", error);
+        } finally {
+            setActionLoading((prev) => ({ ...prev, [userId]: false }));
+        }
+    };
+
+    return (
+        <div className="mb-8">
+            <h2 className="mb-4 text-2xl font-bold">Find Friends</h2>
+            <div className="mb-6">
+                <Input
+                    type="text"
+                    placeholder="Search by name or email..."
+                    value={query}
+                    // eslint-disable-next-line @typescript-eslint/no-unsafe-argument, @typescript-eslint/no-unsafe-member-access
+                    onChange={(e) => setQuery(e.target.value)}
+                    className="w-full"
+                />
+                <p className="mt-2 text-sm text-muted-foreground">
+                    Type at least 2 characters to search.
+                </p>
+            </div>
+
+            {isSearching && (
+                <div className="p-4 text-center">
+                    <p className="text-muted-foreground">Searching users...</p>
+                </div>
+            )}
+
+            {searchMessageVisible && (
+                <Card>
+                    <CardContent className="p-6">
+                        <p className="text-center text-muted-foreground">
+                            No users found for &quot;{query}&quot;.
+                        </p>
+                    </CardContent>
+                </Card>
+            )}
+
+            {!isSearching && users.length > 0 && (
+                <div>
+                    {users.map((user) => (
+                        <Card key={user.id} className="mb-4">
+                            <CardContent className="p-6">
+                                <div className="flex items-center justify-between">
+                                    <div className="flex items-center space-x-4">
+                                        <Avatar className="h-12 w-12">
+                                            <AvatarImage
+                                                src={user.imageUrl}
+                                                alt={user.name}
+                                            />
+                                            <AvatarFallback>
+                                                {user.name
+                                                    .substring(0, 2)
+                                                    .toUpperCase()}
+                                            </AvatarFallback>
+                                        </Avatar>
+                                        <div>
+                                            <h3 className="font-medium">
+                                                {user.name}
+                                            </h3>
+                                        </div>
+                                    </div>
+                                    <Button
+                                        variant="default"
+                                        size="sm"
+                                        onClick={() =>
+                                            handleSendRequest(user.id)
+                                        }
+                                        disabled={actionLoading[user.id]}
+                                    >
+                                        {actionLoading[user.id]
+                                            ? "Sending..."
+                                            : "Add Friend"}
+                                    </Button>
+                                </div>
+                            </CardContent>
+                        </Card>
+                    ))}
+                </div>
+            )}
+        </div>
+    );
+}

--- a/src/app/friends/actions.ts
+++ b/src/app/friends/actions.ts
@@ -1,0 +1,418 @@
+"use server";
+
+import { db } from "@/server/db";
+import { friends } from "@/server/db/schema";
+import { auth, clerkClient } from "@clerk/nextjs/server";
+import { and, eq, or } from "drizzle-orm";
+import { revalidatePath } from "next/cache";
+
+// Get all friends and friend requests for the current user
+export async function getFriends() {
+    const { userId } = await auth();
+    if (!userId) {
+        return { error: "Not authenticated" };
+    }
+
+    try {
+        // Get all friend relationships where the current user is involved
+        const friendships = await db
+            .select({
+                id: friends.id,
+                userId: friends.userId,
+                friendId: friends.friendId,
+                status: friends.status,
+                createdAt: friends.createdAt,
+            })
+            .from(friends)
+            .where(
+                or(eq(friends.userId, userId), eq(friends.friendId, userId)),
+            );
+
+        if (!friendships.length) {
+            return {
+                friends: [],
+                pendingReceived: [],
+                pendingSent: [],
+            };
+        }
+
+        // Get all user IDs from the friendships
+        const userIds = new Set<string>();
+        friendships.forEach((f) => {
+            userIds.add(f.userId);
+            userIds.add(f.friendId);
+        });
+
+        // Remove the current user's ID
+        userIds.delete(userId);
+
+        // Get user information for all friends
+        const friendUserIds = Array.from(userIds);
+        const userDetails = await (
+            await clerkClient()
+        ).users.getUserList({
+            userId: friendUserIds,
+        });
+
+        // Split relationships into different categories
+        const acceptedFriends = [];
+        const pendingReceived = [];
+        const pendingSent = [];
+        
+        // Keep track of friends already processed to avoid duplicates
+        const processedFriendIds = new Set<string>();
+
+        for (const friendship of friendships) {
+            const isInitiator = friendship.userId === userId;
+            const otherUserId = isInitiator
+                ? friendship.friendId
+                : friendship.userId;
+            const userDetail = userDetails.data.find(
+                (u) => u.id === otherUserId,
+            );
+
+            if (!userDetail) continue;
+
+            const friendInfo = {
+                relationshipId: friendship.id,
+                userId: otherUserId,
+                name:
+                    userDetail.firstName && userDetail.lastName
+                        ? `${userDetail.firstName} ${userDetail.lastName}`
+                        : (userDetail.emailAddresses[0]?.emailAddress ??
+                          otherUserId),
+                imageUrl: userDetail.imageUrl ?? undefined,
+                initiatedByMe: isInitiator,
+                createdAt: friendship.createdAt,
+            };
+
+            if (friendship.status === "accepted") {
+                // Only add to acceptedFriends if this user hasn't been processed yet
+                if (!processedFriendIds.has(otherUserId)) {
+                    acceptedFriends.push(friendInfo);
+                    processedFriendIds.add(otherUserId);
+                }
+            } else if (friendship.status === "pending") {
+                if (isInitiator) {
+                    pendingSent.push(friendInfo);
+                } else {
+                    pendingReceived.push(friendInfo);
+                }
+            }
+        }
+
+        return {
+            friends: acceptedFriends,
+            pendingReceived,
+            pendingSent,
+        };
+    } catch (error) {
+        console.error("Error fetching friends:", error);
+        return { error: "Failed to fetch friends" };
+    }
+}
+
+// Search for users who are not already friends or have pending requests
+export async function searchUsers(query: string) {
+    const { userId } = await auth();
+    if (!userId || !query || query.length < 2) {
+        return { users: [] };
+    }
+
+    try {
+        // Get all existing friend relationships for this user
+        const existingRelations = await db
+            .select({
+                userId: friends.userId,
+                friendId: friends.friendId,
+            })
+            .from(friends)
+            .where(
+                or(eq(friends.userId, userId), eq(friends.friendId, userId)),
+            );
+
+        // Create a set of user IDs that are already in some relationship with the current user
+        const relatedUserIds = new Set<string>();
+        existingRelations.forEach((relation) => {
+            if (relation.userId !== userId) relatedUserIds.add(relation.userId);
+            if (relation.friendId !== userId)
+                relatedUserIds.add(relation.friendId);
+        });
+
+        // Also exclude the current user
+        relatedUserIds.add(userId);
+
+        // Search for users using Clerk whose ID is not in relatedUserIds
+        const clerkUsers = await (
+            await clerkClient()
+        ).users.getUserList({
+            query,
+            limit: 10,
+        });
+
+        // Filter out users who are already related to the current user
+        const filteredUsers = clerkUsers.data
+            .filter((user) => !relatedUserIds.has(user.id))
+            .map((user) => ({
+                id: user.id,
+                name:
+                    user.firstName && user.lastName
+                        ? `${user.firstName} ${user.lastName}`
+                        : (user.emailAddresses[0]?.emailAddress ?? user.id),
+                imageUrl: user.imageUrl ?? undefined,
+            }));
+
+        return { users: filteredUsers };
+    } catch (error) {
+        console.error("Error searching users:", error);
+        return { error: "Failed to search users" };
+    }
+}
+
+// Send a friend request
+export async function sendFriendRequest(friendId: string) {
+    const { userId } = await auth();
+    if (!userId) {
+        return { error: "Not authenticated" };
+    }
+
+    if (userId === friendId) {
+        return { error: "Cannot add yourself as a friend" };
+    }
+
+    try {
+        // Check if a relationship already exists
+        const existingRelation = await db
+            .select()
+            .from(friends)
+            .where(
+                or(
+                    and(
+                        eq(friends.userId, userId),
+                        eq(friends.friendId, friendId),
+                    ),
+                    and(
+                        eq(friends.userId, friendId),
+                        eq(friends.friendId, userId),
+                    ),
+                ),
+            );
+
+        if (existingRelation.length > 0) {
+            return { error: "Friend request already exists" };
+        }
+
+        try {
+            // Check if the friend exists in the system
+            const friendExists = await (
+                await clerkClient()
+            ).users.getUser(friendId);
+            if (!friendExists) {
+                return { error: "User not found" };
+            }
+        } catch {
+            return { error: "User not found" };
+        }
+
+        // Create a new friend request (from initiator to recipient)
+        await db.insert(friends).values({
+            userId,
+            friendId,
+            status: "pending",
+        });
+
+        revalidatePath("/friends");
+        return { success: true };
+    } catch (error) {
+        console.error("Error sending friend request:", error);
+        return { error: "Failed to send friend request" };
+    }
+}
+
+// Accept a friend request
+export async function acceptFriendRequest(relationId: bigint) {
+    const { userId } = await auth();
+    if (!userId) {
+        return { error: "Not authenticated" };
+    }
+
+    try {
+        // Find the pending relation
+        const relation = await db
+            .select({
+                id: friends.id,
+                userId: friends.userId,
+                friendId: friends.friendId,
+                status: friends.status,
+            })
+            .from(friends)
+            .where(
+                and(
+                    eq(friends.id, relationId),
+                    eq(friends.friendId, userId),
+                    eq(friends.status, "pending"),
+                ),
+            );
+
+        if (relation.length === 0) {
+            return { error: "Friend request not found" };
+        }
+
+        const friendRelation = relation[0]!;
+
+        // Ensure the relationship is valid
+        if (!friendRelation.userId) {
+            return { error: "Invalid friend relationship - missing userId" };
+        }
+
+        // Update the status of the current relationship to accepted
+        await db
+            .update(friends)
+            .set({ status: "accepted" })
+            .where(eq(friends.id, relationId));
+
+        // Check if a reverse relationship already exists
+        const existingReverseRelation = await db
+            .select()
+            .from(friends)
+            .where(
+                and(
+                    eq(friends.userId, userId),
+                    eq(friends.friendId, friendRelation.userId),
+                ),
+            );
+
+        // If no reverse relationship exists, create one with accepted status
+        if (existingReverseRelation.length === 0) {
+            await db.insert(friends).values({
+                userId: userId,
+                friendId: friendRelation.userId,
+                status: "accepted",
+            });
+        } else {
+            // If it exists, update it to accepted
+            await db
+                .update(friends)
+                .set({ status: "accepted" })
+                .where(
+                    and(
+                        eq(friends.userId, userId),
+                        eq(friends.friendId, friendRelation.userId),
+                    ),
+                );
+        }
+
+        revalidatePath("/friends");
+        return { success: true };
+    } catch (error) {
+        console.error("Error accepting friend request:", error);
+        return { error: "Failed to accept friend request" };
+    }
+}
+
+// Reject or cancel a friend request
+export async function rejectFriendRequest(relationId: bigint) {
+    const { userId } = await auth();
+    if (!userId) {
+        return { error: "Not authenticated" };
+    }
+
+    try {
+        const relation = await db
+            .select()
+            .from(friends)
+            .where(
+                and(
+                    eq(friends.id, relationId),
+                    or(
+                        eq(friends.friendId, userId),
+                        eq(friends.userId, userId),
+                    ),
+                    eq(friends.status, "pending"),
+                ),
+            );
+
+        if (relation.length === 0) {
+            return { error: "Friend request not found" };
+        }
+
+        // Delete the friend request
+        await db.delete(friends).where(eq(friends.id, relationId));
+
+        revalidatePath("/friends");
+        return { success: true };
+    } catch (error) {
+        console.error("Error rejecting friend request:", error);
+        return { error: "Failed to reject friend request" };
+    }
+}
+
+// Remove a friend
+export async function removeFriend(relationId: bigint) {
+    const { userId } = await auth();
+    if (!userId) {
+        return { error: "Not authenticated" };
+    }
+
+    try {
+        // Find the friend relationship to remove
+        const relation = await db
+            .select({
+                id: friends.id,
+                userId: friends.userId,
+                friendId: friends.friendId,
+                status: friends.status,
+            })
+            .from(friends)
+            .where(
+                and(
+                    eq(friends.id, relationId),
+                    or(
+                        eq(friends.friendId, userId),
+                        eq(friends.userId, userId),
+                    ),
+                    eq(friends.status, "accepted"),
+                ),
+            );
+
+        if (relation.length === 0) {
+            return { error: "Friend relationship not found" };
+        }
+
+        const friendRelation = relation[0]!;
+
+        // Determine the other user's ID
+        const otherUserId =
+            friendRelation.userId === userId
+                ? friendRelation.friendId
+                : friendRelation.userId;
+
+        // Delete the current relationship
+        await db.delete(friends).where(eq(friends.id, relationId));
+
+        // Delete the inverse relationship if it exists
+        await db
+            .delete(friends)
+            .where(
+                and(
+                    or(
+                        and(
+                            eq(friends.userId, userId),
+                            eq(friends.friendId, otherUserId),
+                        ),
+                        and(
+                            eq(friends.userId, otherUserId),
+                            eq(friends.friendId, userId),
+                        ),
+                    ),
+                    eq(friends.status, "accepted"),
+                ),
+            );
+
+        revalidatePath("/friends");
+        return { success: true };
+    } catch (error) {
+        console.error("Error removing friend:", error);
+        return { error: "Failed to remove friend" };
+    }
+}

--- a/src/app/friends/check-auth.ts
+++ b/src/app/friends/check-auth.ts
@@ -1,0 +1,12 @@
+import { auth } from "@clerk/nextjs/server";
+import { redirect } from "next/navigation";
+
+export async function checkAuth(): Promise<string> {
+    const { userId } = await auth();
+    
+    if (!userId) {
+        redirect("/");
+    }
+    
+    return userId;
+}

--- a/src/app/friends/loading.tsx
+++ b/src/app/friends/loading.tsx
@@ -1,0 +1,46 @@
+import { Card, CardContent } from "@/components/ui/card";
+import { Skeleton } from "@/components/ui/skeleton";
+
+export default function Loading() {
+    return (
+        <div className="container max-w-4xl mx-auto py-8 px-4">
+            <div className="mb-8">
+                <Skeleton className="h-10 w-48 mb-4" />
+                
+                {[1, 2, 3].map((i) => (
+                    <Card key={i} className="mb-4">
+                        <CardContent className="p-6">
+                            <div className="flex items-center justify-between">
+                                <div className="flex items-center space-x-4">
+                                    <Skeleton className="h-12 w-12 rounded-full" />
+                                    <div>
+                                        <Skeleton className="h-4 w-32 mb-2" />
+                                        <Skeleton className="h-3 w-40" />
+                                    </div>
+                                </div>
+                                <Skeleton className="h-8 w-24" />
+                            </div>
+                        </CardContent>
+                    </Card>
+                ))}
+            </div>
+
+            <div className="mb-8">
+                <Skeleton className="h-10 w-48 mb-4" />
+                <Card>
+                    <CardContent className="p-6">
+                        <Skeleton className="h-8 w-full mx-auto" />
+                    </CardContent>
+                </Card>
+            </div>
+
+            <div className="mb-8">
+                <Skeleton className="h-10 w-48 mb-4" />
+                <div className="mb-6">
+                    <Skeleton className="h-10 w-full mb-2" />
+                    <Skeleton className="h-3 w-48" />
+                </div>
+            </div>
+        </div>
+    );
+}

--- a/src/app/friends/page.tsx
+++ b/src/app/friends/page.tsx
@@ -1,0 +1,95 @@
+import { Card, CardContent } from "@/components/ui/card";
+import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
+import {
+    FriendRequestsList,
+    FriendsList,
+    PendingRequestsList,
+} from "./_components/friend-list";
+import { UserSearch } from "./_components/user-search";
+import { getFriends } from "./actions";
+import { checkAuth } from "./check-auth";
+
+// export const dynamic = "force-dynamic";
+
+export default async function FriendsPage() {
+    // Check if user is authenticated
+    await checkAuth();
+
+    // Fetch all friend data
+    const {
+        friends = [],
+        pendingReceived = [],
+        pendingSent = [],
+        error,
+    } = await getFriends();
+
+    return (
+        <div className="container mx-auto max-w-4xl px-4 py-8">
+            <div className="mb-6 flex flex-col items-start justify-between gap-2 md:flex-row md:items-center">
+                <h1 className="text-3xl font-bold">Friends</h1>
+                {pendingReceived.length > 0 && (
+                    <div className="rounded-full bg-primary px-3 py-1 text-sm font-medium text-primary-foreground">
+                        {pendingReceived.length} pending request
+                        {pendingReceived.length > 1 ? "s" : ""}
+                    </div>
+                )}
+            </div>
+
+            {error && (
+                <Card className="mb-6">
+                    <CardContent className="p-6">
+                        <p className="text-destructive">Error: {error}</p>
+                    </CardContent>
+                </Card>
+            )}
+
+            <Tabs defaultValue="friends" className="mb-8 w-full">
+                <TabsList className="mb-6 grid w-full grid-cols-3">
+                    <TabsTrigger value="friends">
+                        My Friends
+                        {friends.length > 0 && (
+                            <span className="ml-2 rounded-full bg-muted px-2 py-0.5 text-xs text-muted-foreground">
+                                {friends.length}
+                            </span>
+                        )}
+                    </TabsTrigger>
+                    <TabsTrigger value="requests">
+                        Requests
+                        {pendingReceived.length > 0 && (
+                            <span className="ml-2 rounded-full bg-primary px-2 py-0.5 text-xs text-primary-foreground">
+                                {pendingReceived.length}
+                            </span>
+                        )}
+                    </TabsTrigger>
+                    <TabsTrigger value="find">Find Friends</TabsTrigger>
+                </TabsList>
+
+                <TabsContent value="friends">
+                    <FriendsList
+                        friends={friends}
+                        title="My Friends"
+                        emptyMessage="You don't have any friends yet. Add some friends to get started!"
+                    />
+
+                    <PendingRequestsList
+                        requests={pendingSent}
+                        title="Pending Sent Requests"
+                        emptyMessage="You don't have any pending sent friend requests."
+                    />
+                </TabsContent>
+
+                <TabsContent value="requests">
+                    <FriendRequestsList
+                        requests={pendingReceived}
+                        title="Friend Requests"
+                        emptyMessage="You don't have any pending friend requests."
+                    />
+                </TabsContent>
+
+                <TabsContent value="find">
+                    <UserSearch />
+                </TabsContent>
+            </Tabs>
+        </div>
+    );
+}

--- a/src/components/ui-parts/NavBar.tsx
+++ b/src/components/ui-parts/NavBar.tsx
@@ -14,6 +14,7 @@ const navigationLinks = [
     { name: "Dashboard", href: "/dashboard" },
     { name: "Leaderboard", href: "/leaderboard" },
     { name: "Feed", href: "/feed" },
+    { name: "Friends", href: "/friends" },
 ] as const;
 
 export function NavBar() {

--- a/src/components/ui/input.tsx
+++ b/src/components/ui/input.tsx
@@ -1,0 +1,22 @@
+import * as React from "react"
+
+import { cn } from "@/lib/utils"
+
+const Input = React.forwardRef<HTMLInputElement, React.ComponentProps<"input">>(
+  ({ className, type, ...props }, ref) => {
+    return (
+      <input
+        type={type}
+        className={cn(
+          "flex h-9 w-full rounded-md border border-input bg-transparent px-3 py-1 text-base shadow-sm transition-colors file:border-0 file:bg-transparent file:text-sm file:font-medium file:text-foreground placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring disabled:cursor-not-allowed disabled:opacity-50 md:text-sm",
+          className
+        )}
+        ref={ref}
+        {...props}
+      />
+    )
+  }
+)
+Input.displayName = "Input"
+
+export { Input }

--- a/src/components/ui/tabs.tsx
+++ b/src/components/ui/tabs.tsx
@@ -1,0 +1,55 @@
+"use client"
+
+import * as React from "react"
+import * as TabsPrimitive from "@radix-ui/react-tabs"
+
+import { cn } from "@/lib/utils"
+
+const Tabs = TabsPrimitive.Root
+
+const TabsList = React.forwardRef<
+  React.ElementRef<typeof TabsPrimitive.List>,
+  React.ComponentPropsWithoutRef<typeof TabsPrimitive.List>
+>(({ className, ...props }, ref) => (
+  <TabsPrimitive.List
+    ref={ref}
+    className={cn(
+      "inline-flex h-9 items-center justify-center rounded-lg bg-muted p-1 text-muted-foreground",
+      className
+    )}
+    {...props}
+  />
+))
+TabsList.displayName = TabsPrimitive.List.displayName
+
+const TabsTrigger = React.forwardRef<
+  React.ElementRef<typeof TabsPrimitive.Trigger>,
+  React.ComponentPropsWithoutRef<typeof TabsPrimitive.Trigger>
+>(({ className, ...props }, ref) => (
+  <TabsPrimitive.Trigger
+    ref={ref}
+    className={cn(
+      "inline-flex items-center justify-center whitespace-nowrap rounded-md px-3 py-1 text-sm font-medium ring-offset-background transition-all focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50 data-[state=active]:bg-background data-[state=active]:text-foreground data-[state=active]:shadow",
+      className
+    )}
+    {...props}
+  />
+))
+TabsTrigger.displayName = TabsPrimitive.Trigger.displayName
+
+const TabsContent = React.forwardRef<
+  React.ElementRef<typeof TabsPrimitive.Content>,
+  React.ComponentPropsWithoutRef<typeof TabsPrimitive.Content>
+>(({ className, ...props }, ref) => (
+  <TabsPrimitive.Content
+    ref={ref}
+    className={cn(
+      "mt-2 ring-offset-background focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2",
+      className
+    )}
+    {...props}
+  />
+))
+TabsContent.displayName = TabsPrimitive.Content.displayName
+
+export { Tabs, TabsList, TabsTrigger, TabsContent }

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -4,6 +4,7 @@ const isProtectedRoute = createRouteMatcher([
     "/import(.*)",
     "/leaderboard(.*)",
     "/feed(.*)",
+    "/friends(.*)",
 ]);
 
 export default clerkMiddleware(async (auth, req) => {

--- a/src/server/db/schema.ts
+++ b/src/server/db/schema.ts
@@ -11,6 +11,7 @@ import {
     pgTableCreator,
     primaryKey,
     timestamp,
+    uniqueIndex,
     varchar,
 } from "drizzle-orm/pg-core";
 
@@ -151,6 +152,10 @@ export const friends = createTable(
     (table) => ({
         userIdIndex: index("f_user_id_idx").on(table.userId),
         friendIdIndex: index("f_friend_id_idx").on(table.friendId),
+        uniqueFriendship: uniqueIndex("unique_friendship_idx").on(
+            table.userId,
+            table.friendId,
+        ),
     }),
 );
 

--- a/src/server/db/schema.ts
+++ b/src/server/db/schema.ts
@@ -7,6 +7,7 @@ import {
     boolean,
     index,
     integer,
+    pgEnum,
     pgTableCreator,
     primaryKey,
     timestamp,
@@ -118,6 +119,38 @@ export const users = createTable(
     },
     (table) => ({
         spotifyIdIndex: index("u_spotify_id_idx").on(table.spotifyId),
+    }),
+);
+
+export const friendStatus = pgEnum("friend_status", [
+    "pending",
+    "accepted",
+    "rejected",
+]);
+
+export const friends = createTable(
+    "friends",
+    {
+        id: bigserial("id", { mode: "bigint" }).primaryKey(),
+        // The user who "sent" the friend request
+        userId: varchar("user_id", { length: 256 })
+            .notNull()
+            .references(() => users.id, { onDelete: "cascade" }),
+        // The user who "accepted" the friend request
+        friendId: varchar("friend_id", { length: 256 })
+            .notNull()
+            .references(() => users.id, { onDelete: "cascade" }),
+        status: friendStatus("status").notNull(),
+        createdAt: timestamp("created_at", { withTimezone: true })
+            .default(sql`CURRENT_TIMESTAMP`)
+            .notNull(),
+        updatedAt: timestamp("updated_at", { withTimezone: true }).$onUpdate(
+            () => new Date(),
+        ),
+    },
+    (table) => ({
+        userIdIndex: index("f_user_id_idx").on(table.userId),
+        friendIdIndex: index("f_friend_id_idx").on(table.friendId),
     }),
 );
 

--- a/src/server/lib.ts
+++ b/src/server/lib.ts
@@ -101,11 +101,7 @@ export function chunkArray<T>(arr: T[], chunkSize: number) {
     return chunks;
 }
 
-export async function userIsAllowedToAccess(
-    userId: string,
-    // the user they're trying to access
-    targetUserId: string,
-) {
+export async function usersAreFriends(user1Id: string, user2Id: string) {
     "use cache";
 
     cacheLife({
@@ -120,8 +116,8 @@ export async function userIsAllowedToAccess(
         .from(schema.friends)
         .where(
             and(
-                eq(schema.friends.friendId, targetUserId),
-                eq(schema.friends.userId, userId),
+                eq(schema.friends.userId, user1Id),
+                eq(schema.friends.friendId, user2Id),
                 eq(schema.friends.status, "accepted"),
             ),
         );

--- a/src/server/lib.ts
+++ b/src/server/lib.ts
@@ -1,7 +1,8 @@
 import { db } from "@/server/db";
-import { listeningHistory, users } from "@/server/db/schema";
+import * as schema from "@/server/db/schema";
 import { type clerkClient } from "@clerk/nextjs/server";
-import { and, gte, lte } from "drizzle-orm";
+import { and, eq, gte, lte } from "drizzle-orm";
+import { unstable_cacheLife as cacheLife } from "next/cache";
 import "server-only";
 
 export function getBaseUrl() {
@@ -25,8 +26,8 @@ export interface DateRange {
 
 export function getTimeFilters(dateRange: DateRange) {
     const timeFilters = and(
-        gte(listeningHistory.playedAt, dateRange.from),
-        lte(listeningHistory.playedAt, dateRange.to),
+        gte(schema.listeningHistory.playedAt, dateRange.from),
+        lte(schema.listeningHistory.playedAt, dateRange.to),
     );
 
     return timeFilters;
@@ -40,7 +41,7 @@ export async function setUserTracking(
     "use server";
 
     const dbUsers = await db
-        .insert(users)
+        .insert(schema.users)
         .values({
             id: userId,
             spotifyId: spotifyId,
@@ -48,7 +49,7 @@ export async function setUserTracking(
             enabled,
         })
         .onConflictDoUpdate({
-            target: users.id,
+            target: schema.users.id,
             set: { enabled },
         })
         .returning();
@@ -98,4 +99,60 @@ export function chunkArray<T>(arr: T[], chunkSize: number) {
         chunks.push(chunk);
     }
     return chunks;
+}
+
+export async function userIsAllowedToAccess(
+    userId: string,
+    // the user they're trying to access
+    targetUserId: string,
+) {
+    "use cache";
+
+    cacheLife({
+        stale: 10,
+        revalidate: 10,
+        expire: 10,
+    });
+
+    // Check if the target user is the friend of the user
+    const friends = await db
+        .select()
+        .from(schema.friends)
+        .where(
+            and(
+                eq(schema.friends.friendId, targetUserId),
+                eq(schema.friends.userId, userId),
+                eq(schema.friends.status, "accepted"),
+            ),
+        );
+
+    if (friends.length > 0) {
+        return true;
+    }
+
+    return false;
+}
+
+export async function getUserFriends(userId: string) {
+    "use cache";
+
+    cacheLife({
+        stale: 10,
+        revalidate: 10,
+        expire: 10,
+    });
+
+    const friends = await db
+        .select({
+            friendId: schema.friends.friendId,
+        })
+        .from(schema.friends)
+        .where(
+            and(
+                eq(schema.friends.userId, userId),
+                eq(schema.friends.status, "accepted"),
+            ),
+        );
+
+    return friends.map((friend) => friend.friendId);
 }


### PR DESCRIPTION
Handles #14 

Adds a friends page to manage friends.

Friends will add a layer of access control to the leaderboard, feed and dashboard pages by only allowing friends to see your data on these pages. [STILL TO IMPLEMENT]

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Launched a comprehensive Friends Management interface featuring separate sections for your friends, incoming requests, and friend discovery.
  - Enabled friend search functionality by name or email, with clear visual feedback during actions.
  - Added a “Friends” link in the main navigation for quick access.
  - Rolled out polished loading states using animated skeleton screens to enhance the user experience.
  - Introduced development guidelines in `CLAUDE.md` for better project onboarding.
  - Expanded UI components with new tab functionality for enhanced navigation.
  - Introduced new components for managing friend relationships, including friend cards and lists.
  - Added new input and tab components to improve UI consistency.
  - Implemented an API endpoint for development purposes to create friendships among all users.

- **Bug Fixes**
  - Improved error handling for friend management actions to ensure a smoother user experience.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->